### PR TITLE
:wrench: PIC-1497: Updated to include autoscaling

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,30 +1,35 @@
 
-minReplicaCount: 1
-maxReplicaCount: 2
+generic-service:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 100
 
-springProfiles: sqs-read
 
-image:
-  repository: quay.io/hmpps/court-list-splitter
-  tag: latest
-  port: 8080
+  springProfiles: sqs-read
 
-ingress:
-  enabled: true
-  enable_whitelist: true
-  hosts:
-    - host: court-list-splitter-dev.hmpps.service.justice.gov.uk
-      cert_secret: court-probation-dev-cert-secret
-  path: /
+  image:
+    repository: quay.io/hmpps/court-list-splitter
+    tag: latest
+    port: 8080
 
-env:
-  JAVA_OPTS: "-Xmx512m"
+  ingress:
+    enabled: true
+    enable_whitelist: true
+    hosts:
+      - host: court-list-splitter-dev.hmpps.service.justice.gov.uk
+        cert_secret: court-probation-dev-cert-secret
+    path: /
 
-whitelist:
-  office: "217.33.148.210/32"
-  health-kick: "35.177.252.195/32"
-  mojvpn: "81.134.202.29/32"
-  cloudplatform-live1-1: "35.178.209.113/32"
-  cloudplatform-live1-2: "3.8.51.207/32"
-  cloudplatform-live1-3: "35.177.252.54/32"
+  env:
+    JAVA_OPTS: "-Xmx512m"
+
+  whitelist:
+    office: "217.33.148.210/32"
+    health-kick: "35.177.252.195/32"
+    mojvpn: "81.134.202.29/32"
+    cloudplatform-live1-1: "35.178.209.113/32"
+    cloudplatform-live1-2: "3.8.51.207/32"
+    cloudplatform-live1-3: "35.177.252.54/32"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,37 +1,44 @@
+generic-service:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 100
 
-minReplicaCount: 2
-maxReplicaCount: 4
 
-springProfiles: ""
+  minReplicaCount: 2
+  maxReplicaCount: 4
 
-image:
-  repository: quay.io/hmpps/court-list-splitter
-  tag: latest
-  port: 8080
+  springProfiles: ""
 
-ingress:
-  enabled: true
-  enable_whitelist: true
-  hosts:
-    - host: court-list-splitter-preprod.hmpps.service.justice.gov.uk
-      cert_secret: court-probation-preprod-cert-secret
-  path: /
+  image:
+    repository: quay.io/hmpps/court-list-splitter
+    tag: latest
+    port: 8080
 
-env:
-  JAVA_OPTS: "-Xmx512m"
+  ingress:
+    enabled: true
+    enable_whitelist: true
+    hosts:
+      - host: court-list-splitter-preprod.hmpps.service.justice.gov.uk
+        cert_secret: court-probation-preprod-cert-secret
+    path: /
 
-whitelist:
-  office: "217.33.148.210/32"
-  health-kick: "35.177.252.195/32"
-  mojvpn: "81.134.202.29/32"
-  cloudplatform-live1-1: "35.178.209.113/32"
-  cloudplatform-live1-2: "3.8.51.207/32"
-  cloudplatform-live1-3: "35.177.252.54/32"
+  env:
+    JAVA_OPTS: "-Xmx512m"
 
-resources:
-  cpu:
-    limit: 1000m
-    request: 50m
-  memory:
-    limit: 1000Mi
-    request: 500Mi
+  whitelist:
+    office: "217.33.148.210/32"
+    health-kick: "35.177.252.195/32"
+    mojvpn: "81.134.202.29/32"
+    cloudplatform-live1-1: "35.178.209.113/32"
+    cloudplatform-live1-2: "3.8.51.207/32"
+    cloudplatform-live1-3: "35.177.252.54/32"
+
+  resources:
+    cpu:
+      limit: 1000m
+      request: 50m
+    memory:
+      limit: 1000Mi
+      request: 500Mi

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,37 +1,41 @@
 
-minReplicaCount: 2
-maxReplicaCount: 4
+generic-service:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 100
 
-springProfiles: ""
+  springProfiles: ""
 
-image:
-  repository: quay.io/hmpps/court-list-splitter
-  tag: latest
-  port: 8080
+  image:
+    repository: quay.io/hmpps/court-list-splitter
+    tag: latest
+    port: 8080
 
-ingress:
-  enabled: true
-  enable_whitelist: true
-  hosts:
-    - host: court-list-splitter.hmpps.service.justice.gov.uk
-      cert_secret: court-probation-cert-secret
-  path: /
+  ingress:
+    enabled: true
+    enable_whitelist: true
+    hosts:
+      - host: court-list-splitter.hmpps.service.justice.gov.uk
+        cert_secret: court-probation-cert-secret
+    path: /
 
-env:
-  JAVA_OPTS: "-Xmx512m"
+  env:
+    JAVA_OPTS: "-Xmx512m"
 
-whitelist:
-  office: "217.33.148.210/32"
-  health-kick: "35.177.252.195/32"
-  mojvpn: "81.134.202.29/32"
-  cloudplatform-live1-1: "35.178.209.113/32"
-  cloudplatform-live1-2: "3.8.51.207/32"
-  cloudplatform-live1-3: "35.177.252.54/32"
+  whitelist:
+    office: "217.33.148.210/32"
+    health-kick: "35.177.252.195/32"
+    mojvpn: "81.134.202.29/32"
+    cloudplatform-live1-1: "35.178.209.113/32"
+    cloudplatform-live1-2: "3.8.51.207/32"
+    cloudplatform-live1-3: "35.177.252.54/32"
 
-resources:
-  cpu:
-    limit: 1000m
-    request: 50m
-  memory:
-    limit: 1000Mi
-    request: 500Mi
+  resources:
+    cpu:
+      limit: 1000m
+      request: 50m
+    memory:
+      limit: 1000Mi
+      request: 500Mi


### PR DESCRIPTION
The [generic-service](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service) includes the hpa.yaml file and the following default values for autoscaling:

```
autoscaling:
  enabled: false
  minReplicas: 1
  maxReplicas: 100
  targetCPUUtilizationPercentage: 80
```
The values set in values-[environment].yaml override the default values set in the generic-service chart so we can customise autoscaling to suit our needs.

This PR adds the values we need for autoscaling for each environment, to use the generic-service we need to put all the values under generic-service