### PR TITLE
:wrench: PIC-1497: added autoscaling

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,3 +9,9 @@ generic-service:
         cert_secret: court-probation-dev-cert-secret
     path: /
 
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 100
+

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,3 +16,9 @@ generic-service:
     memory:
       limit: 1000Mi
       request: 500Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 100

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,3 +16,9 @@ generic-service:
     memory:
       limit: 1000Mi
       request: 500Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 100


### PR DESCRIPTION
The generic-service includes the hpa.yaml file and the following default values for autoscaling:

```
autoscaling:
  enabled: false
  minReplicas: 1
  maxReplicas: 100
  targetCPUUtilizationPercentage: 80
```
The values set in values-[environment].yaml override the default values set in the generic-service chart so we can customise autoscaling to suit our needs.
This PR includes adding the values for each environment.