### PR TITLE
:wrench: PIC-1515: added cpu and memory limits

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,3 +15,11 @@ generic-service:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 100
 
+  resources:
+    cpu:
+      limit: 1000m
+      request: 50m
+    memory:
+      limit: 1000Mi
+      request: 500Mi
+


### PR DESCRIPTION
CPU and memory limits are already there for preprod and prod environments so just added for dev. 
The request values are set lower than court-case-service for preprod and prod so I have used those same values for dev.


Signed-off-by: katie-cawthorne <katie.cawthorne@digital.justice.gov.uk>