### PR TITLE
Pic 1515 apply cpu memory limits

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,10 +16,10 @@ generic-service:
     targetCPUUtilizationPercentage: 100
 
   resources:
-    cpu:
-      limit: 5000m
-      request: 250m
-    memory:
-      limit: 1200Mi
-      request: 350Mi
+    limits:
+      cpu: 5000m
+      memory: 1200Mi
+    requests:
+      cpu: 250m
+      memory: 350Mi
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,9 +17,9 @@ generic-service:
 
   resources:
     cpu:
-      limit: 1000m
-      request: 50m
+      limit: 5000m
+      request: 250m
     memory:
-      limit: 1000Mi
-      request: 500Mi
+      limit: 1200Mi
+      request: 350Mi
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,3 +15,11 @@ generic-service:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 100
 
+  resources:
+    cpu:
+      limit: 1000m
+      request: 50m
+    memory:
+      limit: 1000Mi
+      request: 500Mi
+

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,11 +11,11 @@ generic-service:
 
   resources:
     cpu:
-      limit: 1000m
-      request: 50m
+      limit: 5000m
+      request: 500m
     memory:
-      limit: 1000Mi
-      request: 500Mi
+      limit: 1200Mi
+      request: 700Mi
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,12 +10,12 @@ generic-service:
     path: /
 
   resources:
-    cpu:
-      limit: 5000m
-      request: 500m
-    memory:
-      limit: 1200Mi
-      request: 700Mi
+    limits:
+      cpu: 5000m
+      memory: 1200Mi
+    requests:
+      cpu: 500m
+      memory: 700Mi
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,11 +11,11 @@ generic-service:
 
   resources:
     cpu:
-      limit: 1000m
-      request: 50m
+      limit: 5000m
+      request: 500m
     memory:
-      limit: 1000Mi
-      request: 500Mi
+      limit: 1200Mi
+      request: 700Mi
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,12 +10,12 @@ generic-service:
     path: /
 
   resources:
-    cpu:
-      limit: 5000m
-      request: 500m
-    memory:
-      limit: 1200Mi
-      request: 700Mi
+    limits:
+      cpu: 5000m
+      memory: 1200Mi
+    requests:
+      cpu: 500m
+      memory: 700Mi
 
   autoscaling:
     enabled: true


### PR DESCRIPTION
I recognised that the format needs to be different for setting cpu and memory limits to work with generic-service, so this PR updates that.