### PR TITLE
Pic 1515 apply cpu memory limits

### DIFF
--- a/helm_deploy/court-list-splitter/values.yaml
+++ b/helm_deploy/court-list-splitter/values.yaml
@@ -11,8 +11,7 @@ generic-service:
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
-    tlsSecretName: court-list-splitter-cert
+    enable_whitelist: true
     path: /
 
   # Environment variables to load into the deployment

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,10 +16,10 @@ generic-service:
     targetCPUUtilizationPercentage: 100
 
   resources:
-    cpu:
-      limit: 5000m
-      request: 250m
-    memory:
-      limit: 1200Mi
-      request: 350Mi
+    limits:
+      cpu: 5000m
+      memory: 1200Mi
+    requests:
+      cpu: 250m
+      memory: 350Mi
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,9 +17,9 @@ generic-service:
 
   resources:
     cpu:
-      limit: 1000m
-      request: 50m
+      limit: 5000m
+      request: 250m
     memory:
-      limit: 1000Mi
-      request: 500Mi
+      limit: 1200Mi
+      request: 350Mi
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,12 +2,8 @@ generic-service:
   springProfiles: sqs-read
 
   ingress:
-    enabled: true
-    enable_whitelist: true
-    hosts:
-      - host: court-list-splitter-dev.hmpps.service.justice.gov.uk
-        cert_secret: court-probation-dev-cert-secret
-    path: /
+    host: court-list-splitter-dev.hmpps.service.justice.gov.uk
+    tlsSecretName: court-probation-dev-cert-secret
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,3 +15,11 @@ generic-service:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 100
 
+  resources:
+    cpu:
+      limit: 1000m
+      request: 50m
+    memory:
+      limit: 1000Mi
+      request: 500Mi
+

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,11 +11,11 @@ generic-service:
 
   resources:
     cpu:
-      limit: 1000m
-      request: 50m
+      limit: 5000m
+      request: 500m
     memory:
-      limit: 1000Mi
-      request: 500Mi
+      limit: 1200Mi
+      request: 700Mi
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -2,12 +2,8 @@ generic-service:
   springProfiles: sqs-read
 
   ingress:
-    enabled: true
-    enable_whitelist: true
-    hosts:
-      - host: court-list-splitter-preprod.hmpps.service.justice.gov.uk
-        cert_secret: court-probation-preprod-cert-secret
-    path: /
+    host: court-list-splitter-preprod.hmpps.service.justice.gov.uk
+    tlsSecretName: court-probation-preprod-cert-secret
 
   resources:
     limits:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,12 +10,12 @@ generic-service:
     path: /
 
   resources:
-    cpu:
-      limit: 5000m
-      request: 500m
-    memory:
-      limit: 1200Mi
-      request: 700Mi
+    limits:
+      cpu: 5000m
+      memory: 1200Mi
+    requests:
+      cpu: 500m
+      memory: 700Mi
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,11 +11,11 @@ generic-service:
 
   resources:
     cpu:
-      limit: 1000m
-      request: 50m
+      limit: 5000m
+      request: 500m
     memory:
-      limit: 1000Mi
-      request: 500Mi
+      limit: 1200Mi
+      request: 700Mi
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,12 +10,12 @@ generic-service:
     path: /
 
   resources:
-    cpu:
-      limit: 5000m
-      request: 500m
-    memory:
-      limit: 1200Mi
-      request: 700Mi
+    limits:
+      cpu: 5000m
+      memory: 1200Mi
+    requests:
+      cpu: 500m
+      memory: 700Mi
 
   autoscaling:
     enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,12 +2,8 @@ generic-service:
   springProfiles: sqs-read
 
   ingress:
-    enabled: true
-    enable_whitelist: true
-    hosts:
-      - host: court-list-splitter.hmpps.service.justice.gov.uk
-        cert_secret: court-probation-cert-secret
-    path: /
+    host: court-list-splitter.hmpps.service.justice.gov.uk
+    tlsSecretName: court-probation-cert-secret
 
   resources:
     limits:


### PR DESCRIPTION
Ingress isn't configured correctly to work with the generic-service, so this PR makes the necessary changes.
It needs to follow this format:
```
ingress:
  enabled: false
  annotations:
    kubernetes.io/ingress.class: "nginx"
    nginx.ingress.kubernetes.io/custom-http-errors: "418"
  host: chart-example.local
  path: /
  tlsSecretName: chart-example-tls
```
I have also moved out the values used in all environments to `values.yml` 