### PR TITLE
👷‍♂️PIC-1446: Allow passing docker build args as CircleCI parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.11.10
+  hmpps: ministryofjustice/hmpps@3.12.0
   jira: circleci/jira@1.2.2
+
+parameters:
+  additional_docker_build_args:
+    type: string
+    default: ""
 
 executors:
   deployer:
@@ -109,6 +114,7 @@ workflows:
           name: helm_lint
       - hmpps/build_docker:
           name: build_docker
+          additional_docker_build_args: << pipeline.parameters.additional_docker_build_args >>
           filters:
             branches:
               only:


### PR DESCRIPTION
This change allows us to pass additional parameters to the Docker build job. The main intended use for this is to allow us to run the build with the `--no-cache` flag, which should fix [this issue](https://app.circleci.com/pipelines/github/ministryofjustice/court-list-splitter/505/workflows/03460dcb-b7f8-4b3a-a947-74515575593e/jobs/1750). 

There is a fixed version available of the library with that vulnerability and I think what's happening is Docker is using a cached version of an intermediate image so the `apt-get upgrade` command will not be run if we rebuild. Forcing `--no-cache` will ignore this intermediate image for one build, hopefully allowing the upgrade to be performed successfully.