### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.1.0
+  hmpps: ministryofjustice/hmpps@7
   jira: circleci/jira@1.3.1
 
 parameters:

--- a/helm_deploy/court-list-splitter/Chart.yaml
+++ b/helm_deploy/court-list-splitter/Chart.yaml
@@ -5,7 +5,7 @@ name: court-list-splitter
 version: 0.1.0
 dependencies:
   - name: generic-service
-    version: 2.7.4
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/court-list-splitter/values.yaml
+++ b/helm_deploy/court-list-splitter/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: court-list-splitter
 
@@ -8,7 +7,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/court-list-splitter
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
@@ -40,13 +39,8 @@ generic-service:
       AWS_SNS_TOPIC_ARN: topic_arn
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    global-protect: "35.176.93.186/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: court-list-splitter


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/court-list-splitter/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `7 => 0 (7 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
