### PR TITLE
Split prometheus alerts by environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       name: hmpps/localstack
       services: sqs,sns
       jdk_tag: "19.0"
-      localstack_tag: "3.0"
+      localstack_tag: "1.0.1"
     steps:
       - checkout
       - hmpps/install_aws_cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,8 @@ jobs:
       localstack_tag: "2.3.2"
     steps:
       - checkout
-      - hmpps/install_aws_cli
+      - hmpps/install_aws_cli:
+          version: 1
       - run:
           name: Wait for SQS to be ready
           command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       name: hmpps/localstack
       services: sqs,sns
       jdk_tag: "19.0"
-      localstack_tag: "1.0.1"
+      localstack_tag: "2.3.2"
     steps:
       - checkout
       - hmpps/install_aws_cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,11 +54,10 @@ jobs:
       name: hmpps/localstack
       services: sqs,sns
       jdk_tag: "19.0"
-      localstack_tag: "2.3.2"
+      localstack_tag: "latest"
     steps:
       - checkout
-      - hmpps/install_aws_cli:
-          version: "1"
+      - hmpps/install_aws_cli
       - run:
           name: Wait for SQS to be ready
           command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - checkout
       - hmpps/install_aws_cli:
-          version: 1
+          version: "1"
       - run:
           name: Wait for SQS to be ready
           command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
           environment:
             AWS_PROVIDER: localstack
             SPRING_PROFILES_ACTIVE: test
+            HOSTNAME_EXTERNAL: localhost
           command: ./gradlew integrationTest
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       name: hmpps/localstack
       services: sqs,sns
       jdk_tag: "19.0"
-      localstack_tag: "0.14.0"
+      localstack_tag: "3.0"
     steps:
       - checkout
       - hmpps/install_aws_cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       name: hmpps/localstack
       services: sqs,sns
       jdk_tag: "19.0"
-      localstack_tag: "0.11.2"
+      localstack_tag: "0.14.0"
     steps:
       - checkout
       - hmpps/install_aws_cli

--- a/helm_deploy/court-list-splitter/values.yaml
+++ b/helm_deploy/court-list-splitter/values.yaml
@@ -47,7 +47,3 @@ generic-service:
     cloudplatform-live1-2: "3.8.51.207/32"
     cloudplatform-live1-3: "35.177.252.54/32"
     global-protect: "35.176.93.186/32"
-
-generic-prometheus-alerts:
-  targetApplication: court-list-splitter
-  alertSeverity: prepare-a-case

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,3 +21,7 @@ generic-service:
     requests:
       cpu: 250m
       memory: 350Mi
+
+  generic-prometheus-alerts:
+    targetApplication: court-list-splitter
+    alertSeverity: probation_in_court_alerts_dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,3 +18,7 @@ generic-service:
     minReplicas: 2
     maxReplicas: 4
     targetCPUUtilizationPercentage: 100
+
+  generic-prometheus-alerts:
+    targetApplication: court-list-splitter
+    alertSeverity: probation_in_court_alerts_preprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,3 +18,7 @@ generic-service:
     minReplicas: 2
     maxReplicas: 4
     targetCPUUtilizationPercentage: 100
+
+  generic-prometheus-alerts:
+    targetApplication: court-list-splitter
+    alertSeverity: probation_in_court_alerts_prod

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courtlistsplitter/messaging/SqsMessageReceiverIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courtlistsplitter/messaging/SqsMessageReceiverIntTest.kt
@@ -67,7 +67,7 @@ class SqsMessageReceiverIntTest {
 
   @BeforeEach
   fun beforeEach() {
-    sqsClient.purgeQueue(PurgeQueueRequest("http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/crime-portal-gateway-queue"))
+    sqsClient.purgeQueue(PurgeQueueRequest("http://localhost:4566/000000000000/crime-portal-gateway-queue"))
     sqsMessageCounter.reset()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courtlistsplitter/messaging/SqsMessageReceiverIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courtlistsplitter/messaging/SqsMessageReceiverIntTest.kt
@@ -67,7 +67,7 @@ class SqsMessageReceiverIntTest {
 
   @BeforeEach
   fun beforeEach() {
-    sqsClient.purgeQueue(PurgeQueueRequest("http://localhost:4566/000000000000/crime-portal-gateway-queue"))
+    sqsClient.purgeQueue(PurgeQueueRequest("http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/crime-portal-gateway-queue"))
     sqsMessageCounter.reset()
   }
 

--- a/src/test/resources/localstack/setup-sqs.sh
+++ b/src/test/resources/localstack/setup-sqs.sh
@@ -10,10 +10,12 @@ export PAGER=
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue-dlq
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue
 
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
 
 # The topic that the splitter writes to
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue
+
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
+
 aws --endpoint-url=http://localhost:4566 sns create-topic --name court-case-events-topic
 aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol "sqs" --notification-endpoint "http://localhost:4566/000000000000/court-case-matcher-queue"
 

--- a/src/test/resources/localstack/setup-sqs.sh
+++ b/src/test/resources/localstack/setup-sqs.sh
@@ -10,11 +10,11 @@ export PAGER=
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue-dlq
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue
 
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
 
 # The topic that the splitter writes to
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue
 aws --endpoint-url=http://localhost:4566 sns create-topic --name court-case-events-topic
-aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol http --notification-endpoint "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/court-case-matcher-queue"
+aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol http --notification-endpoint "http://localhost:4566/000000000000/court-case-matcher-queue"
 
 echo "SNS and SQS Configured"

--- a/src/test/resources/localstack/setup-sqs.sh
+++ b/src/test/resources/localstack/setup-sqs.sh
@@ -10,7 +10,7 @@ export PAGER=
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue-dlq
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue
 
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
 
 # The topic that the splitter writes to
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue

--- a/src/test/resources/localstack/setup-sqs.sh
+++ b/src/test/resources/localstack/setup-sqs.sh
@@ -10,12 +10,12 @@ export PAGER=
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue-dlq
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue
 
-
-# The topic that the splitter writes to
-aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue
+aws sqs get-queue-attributes --queue-url http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/crime-portal-gateway-queue --attribute-names All
 
 aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
 
+# The topic that the splitter writes to
+aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue
 aws --endpoint-url=http://localhost:4566 sns create-topic --name court-case-events-topic
 aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol "sqs" --notification-endpoint "http://localhost:4566/000000000000/court-case-matcher-queue"
 

--- a/src/test/resources/localstack/setup-sqs.sh
+++ b/src/test/resources/localstack/setup-sqs.sh
@@ -15,7 +15,7 @@ aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "h
 # The topic that the splitter writes to
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue
 aws --endpoint-url=http://localhost:4566 sns create-topic --name court-case-events-topic
-aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol "sqs" --notification-endpoint "http://localhost:4566/000000000000/court-case-matcher-queue"
+aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol "sqs" --notification-endpoint "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/court-case-matcher-queue"
 
 
 

--- a/src/test/resources/localstack/setup-sqs.sh
+++ b/src/test/resources/localstack/setup-sqs.sh
@@ -15,8 +15,6 @@ aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "h
 # The topic that the splitter writes to
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue
 aws --endpoint-url=http://localhost:4566 sns create-topic --name court-case-events-topic
-aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol "sqs" --notification-endpoint "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/court-case-matcher-queue"
-
-
+aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic" --protocol http --notification-endpoint "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/court-case-matcher-queue"
 
 echo "SNS and SQS Configured"

--- a/src/test/resources/localstack/setup-sqs.sh
+++ b/src/test/resources/localstack/setup-sqs.sh
@@ -10,9 +10,7 @@ export PAGER=
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue-dlq
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue
 
-aws sqs get-queue-attributes --queue-url http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/crime-portal-gateway-queue --attribute-names All
-
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"2\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-queue-dlq\"}", "VisibilityTimeout": "0" }'
 
 # The topic that the splitter writes to
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue


### PR DESCRIPTION
Set the prometheus alerts for each values environment files. This should send prometheus alerts to different slack channels depending on the environment.

[hmpp-helm-charts](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-prometheus-alerts)

- Set the severity value to the alertmanager routing setup in cloud platform. This is associated with the alert slack channels
This should then make sure alerts are sent to the preprod slack channel or prod or dev depending on the environment

